### PR TITLE
Work cleanly for people with large WSL profiles

### DIFF
--- a/beep.c
+++ b/beep.c
@@ -306,7 +306,7 @@ void play_beep(beep_parms_t parms) {
 //    do_beep(0);                                         /* stop beep  */
     if (37.0 <= parms.freq && parms.freq <= 32767.0) {
        sprintf(cmd, "powershell.exe"
-" -Command \"[console]::beep(%.1f,%d)\"", parms.freq, parms.length);
+" -NoProfile -NonInteractive -Command \"[console]::beep(%.1f,%d)\"", parms.freq, parms.length);
        int ret = system(cmd);
        if (WIFSIGNALED(ret) &&
              (WTERMSIG(ret) == SIGINT || WTERMSIG(ret) == SIGQUIT))


### PR DESCRIPTION
Adds parameters to the PowerShell invocation to skip loading the user's profile, which greatly speeds execution for people with large or slow operation in their profile. Also looks less incongruous if their PS profile writes to stdout.
